### PR TITLE
Removed six from django.util

### DIFF
--- a/haystack_elasticsearch/elasticsearch.py
+++ b/haystack_elasticsearch/elasticsearch.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
@@ -745,9 +744,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         iso = self._iso_datetime(value)
         if iso:
             return iso
-        elif isinstance(value, six.binary_type):
+        elif isinstance(value, bytes):
             # TODO: Be stricter.
-            return six.text_type(value, errors='replace')
+            return str(value, errors='replace')
         elif isinstance(value, set):
             return list(value)
         return value
@@ -757,7 +756,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         if isinstance(value, (int, float, complex, list, tuple, bool)):
             return value
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             possible_datetime = DATETIME_REGEX.search(value)
 
             if possible_datetime:
@@ -823,7 +822,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             if hasattr(value, 'values_list'):
                 value = list(value)
 
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 # It's not an ``InputType``. Assume ``Clean``.
                 value = Clean(value)
             else:
@@ -866,7 +865,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
                     # Iterate over terms & incorportate the converted form of each into the query.
                     terms = []
 
-                    if isinstance(prepared_value, six.string_types):
+                    if isinstance(prepared_value, str):
                         for possible_value in prepared_value.split(' '):
                             terms.append(filter_types[filter_type] % self.backend._from_python(possible_value))
                     else:
@@ -915,7 +914,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         kwarg_bits = []
 
         for key in sorted(kwargs.keys()):
-            if isinstance(kwargs[key], six.string_types) and ' ' in kwargs[key]:
+            if isinstance(kwargs[key], str) and ' ' in kwargs[key]:
                 kwarg_bits.append(u"%s='%s'" % (key, kwargs[key]))
             else:
                 kwarg_bits.append(u"%s=%s" % (key, kwargs[key]))


### PR DESCRIPTION
Removed references to six from django.utils
Changed Python2 references to Python3, dropped Python2 support and only works with Python3
Now compatible with Django3

reason see: Cedadev/datamad2/issue/425